### PR TITLE
Testing Chimney for Converters

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -99,6 +99,7 @@ object Dependencies {
       // For making Java 12 happy
       "javax.annotation"                       % "javax.annotation-api" % "1.3.2" % "compile",
       //
+      "io.scalaland" %% "chimney" % "0.6.2" % Compile,
       akka.actorTyped                          % Compile,
       akka.management                          % Compile,
       akka.managementLogLevels                 % Compile,


### PR DESCRIPTION
This PR is here to briefly show how chimney can reduce our boilerplate. It has some flaws: it blindly passes fields with the same name, possibly hiding transformations that need to be added for BL reasons. Still, we can consider using it.
I'm using it in a simple way here, but it supports [patching with update objects](https://scalalandio.github.io/chimney/#patching), [nested transformations](https://scalalandio.github.io/chimney/transformers/getting-started.html#nested-transformations) and if an enum contains the other but not the other way around [there's a solution](https://scalalandio.github.io/chimney/transformers/customizing-transformers.html#transforming-coproducts) too.

! There's an [unsafe support](https://scalalandio.github.io/chimney/transformers/unsafe-options.html) meant to be used with scalaPB !
